### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Data/ICal.pm6
+++ b/lib/Data/ICal.pm6
@@ -1,4 +1,4 @@
-class Data::ICal;
+unit class Data::ICal;
 
 use Data::ICal::Grammar;
 use Data::ICal::Event;

--- a/lib/Data/ICal/Event.pm6
+++ b/lib/Data/ICal/Event.pm6
@@ -1,4 +1,4 @@
-class Data::ICal::Event;
+unit class Data::ICal::Event;
 
 has $.uid;
 has $.dtstamp;

--- a/lib/Data/ICal/TimeZone.pm6
+++ b/lib/Data/ICal/TimeZone.pm6
@@ -1,4 +1,4 @@
-class Data::ICal::TimeZone;
+unit class Data::ICal::TimeZone;
 
 has $.tzid;
 has $.std-offset;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
